### PR TITLE
update metadata with gnome 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,8 @@
     "svg-file-name": "DrawOnYourScreen",
     "shell-version": [
         "40",
-        "41"
+        "41",
+        "42"
     ],
     "version": 12.1
 }


### PR DESCRIPTION
To use it in Gnome 42 I had to add the new version in metadata file