### PR TITLE
Keybind fixes

### DIFF
--- a/area.js
+++ b/area.js
@@ -471,6 +471,14 @@ var DrawingArea = GObject.registerClass({
     }
     
     _onKeyPressed(actor, event) {
+        if (event.get_key_symbol() == Clutter.KEY_Escape) {
+            if (this.helper.visible) {
+                this.toggleHelp();
+            } else
+                this.emit('leave-drawing-mode');
+            return Clutter.EVENT_STOP;
+        }
+
         if (this.currentElement && this.currentElement.shape == Shape.LINE &&
             (event.get_key_symbol() == Clutter.KEY_Return ||
              event.get_key_symbol() == Clutter.KEY_KP_Enter ||

--- a/area.js
+++ b/area.js
@@ -455,6 +455,7 @@ var DrawingArea = GObject.registerClass({
                 this.toggleHelp();
             else
                 this.emit('leave-drawing-mode');
+            return Clutter.EVENT_STOP;
         } else if (event.get_key_symbol() == Clutter.KEY_space) {
             this.spaceKeyPressed = true;
         }

--- a/extension.js
+++ b/extension.js
@@ -378,7 +378,7 @@ const AreaManager = GObject.registerClass({
 
         } else {
             // add Shell.ActionMode.NORMAL to keep system keybindings enabled (e.g. Alt + F2 ...)
-            let actionMode = (this.activeArea.isWriting ? WRITING_ACTION_MODE : DRAWING_ACTION_MODE) | Shell.ActionMode.NORMAL;
+            let actionMode = (this.activeArea.isWriting ? WRITING_ACTION_MODE : DRAWING_ACTION_MODE) | Shell.ActionMode.NORMAL  | Shell.ActionMode.OVERVIEW;
             this.grab = Main.pushModal(this.activeArea, { actionMode: actionMode });
             if (this.grab.get_seat_state() === Clutter.GrabState.NONE) {
                 Main.popModal(this.grab);


### PR DESCRIPTION
This fixes the Escape key not closing the drawing overlay in Gnome 42.

It also fixes a bug when enabling drawing mode, opening the Gnome overlay and then pressing Escape, which would close both as it propagated the event.