### PR TITLE
Gnome 46 Support

### DIFF
--- a/area.js
+++ b/area.js
@@ -51,7 +51,7 @@ const TOGGLE_ANIMATION_DURATION = 300; // ms
 const GRID_TILES_HORIZONTAL_NUMBER = 30;
 const COLOR_PICKER_EXTENSION_UUID = 'color-picker@tuberry';
 
-const { Shape, TextAlignment, Transformation } = Elements;
+const { Shape, StaticColor, TextAlignment, Transformation } = Elements;
 const { DisplayStrings } = Menu;
 
 const FontGenericFamilies = ['Sans-Serif', 'Serif', 'Monospace', 'Cursive', 'Fantasy'];
@@ -203,7 +203,7 @@ export const DrawingArea = GObject.registerClass({
         this._currentPalette = palette;
         this.colors = palette[1].map(colorString => this.getColorFromString(colorString, 'White'));
         if (!this.colors[0])
-            this.colors.push(Clutter.Color.get_static(Clutter.StaticColor.WHITE));
+            this.colors.push(StaticColor.WHTIE);
         this._extension.drawingSettings.set_value("tool-palette", new GLib.Variant('(sas)', palette))
     }
 
@@ -355,7 +355,7 @@ export const DrawingArea = GObject.registerClass({
         if (!this.reactive)
             return;
 
-        Clutter.cairo_set_source_color(cr, this.gridColor);
+        cr.setSourceColor(this.gridColor);
 
         let [gridX, gridY] = [0, 0];
         while (gridX < this.monitor.width / 2) {
@@ -976,7 +976,7 @@ export const DrawingArea = GObject.registerClass({
 
     toggleBackground() {
         this.hasBackground = !this.hasBackground;
-        let backgroundColor = this.hasBackground ? this.areaBackgroundColor : Clutter.Color.get_static(Clutter.StaticColor.TRANSPARENT);
+        let backgroundColor = this.hasBackground ? this.areaBackgroundColor : StaticColor.TRANSPARENT;
 
         if (this.ease) {
             this.remove_all_transitions();
@@ -1479,7 +1479,7 @@ export const DrawingArea = GObject.registerClass({
             return color;
 
         log(`${this._extension.metadata.uuid}: "${string}" color cannot be parsed.`);
-        color = Clutter.Color.get_static(Clutter.StaticColor[fallback.toUpperCase()]);
+        color = StaticColor[fallback.toUpperCase()];
         color.toJSON = () => fallback;
         color.toString = () => fallback;
         return color;

--- a/area.js
+++ b/area.js
@@ -203,7 +203,7 @@ export const DrawingArea = GObject.registerClass({
         this._currentPalette = palette;
         this.colors = palette[1].map(colorString => this.getColorFromString(colorString, 'White'));
         if (!this.colors[0])
-            this.colors.push(StaticColor.WHTIE);
+            this.colors.push(StaticColor.WHITE);
         this._extension.drawingSettings.set_value("tool-palette", new GLib.Variant('(sas)', palette))
     }
 

--- a/elements.js
+++ b/elements.js
@@ -30,6 +30,14 @@ import PangoCairo from 'gi://PangoCairo';
 
 import { CURATED_UUID as UUID } from './utils.js';
 
+export const StaticColor = {
+    WHITE: Clutter.Color.new(255, 255, 255, 255),
+    BLUE: Clutter.Color.new(0, 0, 255, 255),
+    TRANSPARENT: Clutter.Color.new(0, 0, 0, 0),
+    BLACK: Clutter.Color.new(0, 0, 0, 255),
+    GRAY: Clutter.Color.new(160, 160, 164, 255),
+    RED: Clutter.Color.new(255, 0, 0, 255)
+}
 
 export const Shape = { NONE: 0, LINE: 1, ELLIPSE: 2, RECTANGLE: 3, TEXT: 4, POLYGON: 5, POLYLINE: 6, IMAGE: 7 };
 export const TextAlignment = { LEFT: 0, CENTER: 1, RIGHT: 2 };
@@ -65,7 +73,7 @@ const MIN_TRANSLATION_DISTANCE = 1;         // px
 const MIN_ROTATION_ANGLE = Math.PI / 1000;  // rad
 const MIN_DRAWING_SIZE = 3;                 // px
 const MIN_INTERMEDIATE_POINT_DISTANCE = 1;  // px, the higher it is, the fewer points there will be
-const MARK_COLOR = Clutter.Color.get_static(Clutter.StaticColor.BLUE);
+const MARK_COLOR = StaticColor.BLUE
 
 export const DrawingElement = function(params) {
     return params.shape == Shape.TEXT ? new TextElement(params) :
@@ -139,8 +147,8 @@ const _DrawingElement = GObject.registerClass({
     
     buildCairo(cr, params) {
         if (this.color)
-            Clutter.cairo_set_source_color(cr, this.color);
-        
+            cr.setSourceColor(this.color);
+
         if (this.line) {
             cr.setLineCap(this.line.lineCap);
             cr.setLineJoin(this.line.lineJoin);
@@ -162,7 +170,7 @@ const _DrawingElement = GObject.registerClass({
             setDummyStroke(cr);
         
         if (SVG_DEBUG_SUPERPOSES_CAIRO) {
-            Clutter.cairo_set_source_color(cr, Clutter.Color.new(255, 0, 0, 255));
+            cr.setSourceColor(StaticColor.RED);
             cr.setLineWidth(this.line.lineWidth / 2 || 1);
         }
         
@@ -198,7 +206,7 @@ const _DrawingElement = GObject.registerClass({
     _addMarks(cr) {
         if (this.showSymmetryElement) {
             setDummyStroke(cr);
-            Clutter.cairo_set_source_color(cr, MARK_COLOR);
+            cr.setSourceColor(MARK_COLOR);
             
             let transformation = this.lastTransformation;
             if (transformation.type == Transformation.REFLECTION) {
@@ -212,8 +220,8 @@ const _DrawingElement = GObject.registerClass({
         
         if (this.showRotationCenter) {
             setDummyStroke(cr);
-            Clutter.cairo_set_source_color(cr, MARK_COLOR);
-            
+            cr.setSourceColor(MARK_COLOR);
+
             let center = this._getTransformedCenter(this.lastTransformation);
             cr.arc(center[0], center[1], INVERSION_CIRCLE_RADIUS, 0, 2 * Math.PI);
             cr.stroke();
@@ -221,8 +229,8 @@ const _DrawingElement = GObject.registerClass({
         
         if (this.showStretchAxes) {
             setDummyStroke(cr);
-            Clutter.cairo_set_source_color(cr, MARK_COLOR);
-            
+            cr.setSourceColor(MARK_COLOR);
+
             let center = this._getTransformedCenter(this.lastTransformation);
             for (let i = 0; i <=1; i++) {
                 cr.moveTo(center[0] - 1000 * Math.cos(i * Math.PI / 2), center[1] - 1000 * Math.sin(i * Math.PI / 2));

--- a/helper.js
+++ b/helper.js
@@ -90,7 +90,7 @@ export const DrawingHelper = GObject.registerClass({
     
     _populate() {
         this.vbox = new St.BoxLayout({ vertical: true });
-        this.add_actor(this.vbox);
+        this.add_child(this.vbox);
         this.vbox.add_child(new St.Label({ text: _("Global") }));
         
         Shortcuts.GLOBAL_KEYBINDINGS.forEach((settingKeys) => {

--- a/menu.js
+++ b/menu.js
@@ -152,7 +152,7 @@ export const DrawingMenu = GObject.registerClass({
         this.menuManager = new PopupMenu.PopupMenuManager(GS_VERSION < '3.33.0' ? { actor: this.area } : this.area);
         this.menuManager.addMenu(this.menu);
         
-        Main.layoutManager.uiGroup.add_actor(this.menu.actor);
+        Main.layoutManager.uiGroup.add_child(this.menu.actor);
         
         this.menu.actor.add_style_class_name('background-menu draw-on-your-screen-menu');
         this.menu.actor.hide();
@@ -180,7 +180,7 @@ export const DrawingMenu = GObject.registerClass({
         delete this.DrawingTool;
         delete this.areaManagerUtils;
         this.menuManager.removeMenu(this.menu);
-        Main.layoutManager.uiGroup.remove_actor(this.menu.actor);
+        Main.layoutManager.uiGroup.remove_child(this.menu.actor);
         this.menu.destroy();
     }
     
@@ -816,7 +816,7 @@ const ActionButton = GObject.registerClass ({
     get label() {
         if (!this._label) {
             this._label = new St.Label({ style_class: 'dash-label' });
-            Main.layoutManager.uiGroup.add_actor(this._label);
+            Main.layoutManager.uiGroup.add_child(this._label);
             this.connect('destroy', () => this._label.destroy());
         }
         

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
     "persistent-file-name": "persistent",
     "svg-file-name": "DrawOnYourScreen",
     "shell-version": [
-        "45"
+        "46"
     ],
     "version": 12.7
 }

--- a/ui/areamanager.js
+++ b/ui/areamanager.js
@@ -328,12 +328,12 @@ export class AreaManager {
         
         if (this.activeArea.get_parent() == Main.uiGroup) {
             Main.uiGroup.set_child_at_index(Main.layoutManager.keyboardBox, this.oldKeyboardIndex);
-            Main.uiGroup.remove_actor(this.activeArea);
+            Main.uiGroup.remove_child(this.activeArea);
             Main.layoutManager._backgroundGroup.insert_child_above(this.activeArea, Main.layoutManager._bgManagers[activeIndex].backgroundActor);
             if (!this.onDesktop)
                 this.activeArea.hide();
         } else {
-            Main.layoutManager._backgroundGroup.remove_actor(this.activeArea);
+            Main.layoutManager._backgroundGroup.remove_child(this.activeArea);
             Main.uiGroup.add_child(this.activeArea);
             // move the keyboard above the area to make it available with text entries
             this.oldKeyboardIndex = Main.uiGroup.get_children().indexOf(Main.layoutManager.keyboardBox);


### PR DESCRIPTION
This PR contains:

1. Change Clutter.StaticColor and Clutter.Color.get_static to new const variable in elements.js (Clutter.StaticColor and Clutter.Color.get_static deprecated in [Clutter14](https://gjs-docs.gnome.org/clutter14~14/))
2. Change Clutter.cairo_set_source_color() to cr.setSourceColor() (Clutter.cairo_set_source_color() deprecated in gnome 46 [source](https://gjs.guide/extensions/upgrading/gnome-shell-46.html#clutter-cairo-hellpers))
3. Change Clutter.Container.add_actor() and Clutter.Container.remove_actor() to Clutter.Actor.add_child() and Clutter.Actor.remove_child() (Change Clutter.Container.add_actor() and Clutter.Container.remove_actor()  deprecated in gnome 46 [source](https://gjs.guide/extensions/upgrading/gnome-shell-46.html#clutter-container))

closes https://github.com/zhrexl/DrawOnYourScreen2/issues/60